### PR TITLE
Allow discovery version ^0.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.4",
         "phpunit/phpunit": "^4.5",
-        "php-http/discovery": "^0.5",
+        "php-http/discovery": "^0.5|^0.6",
         "php-http/message": "~0.2.1",
         "php-http/httplug": "~1.0@dev",
         "guzzlehttp/psr7": "^1.0",


### PR DESCRIPTION
This will allow a PR on Guzzle5 adapter to build.

Related to: https://github.com/php-http/guzzle5-adapter/pull/13